### PR TITLE
感染病床使用率についての注釈を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ const makeJapanHTML = function() {
 			<label><input type=checkbox id='beds'>二種（一般・精神）</label>
 		</div>
 		<div id=beddescription>
-			*感染症使用率（参考） = 現在患者数 / 選択した感染症病床数の合計<br>
+			*感染病床使用率（参考） = 現在患者数 / 選択した感染症病床数の合計<br>
 			*ここで示している感染症病床数は2019年4月1日時点のデータであるため、<br>
 			現在は増床されている可能性があります<br>
 			出典：<a href=https://www.mhlw.go.jp/bunya/kenkou/kekkaku-kansenshou15/02-02.html>感染症指定医療機関の指定状況｜厚生労働省</a>（<a href=bedforinfection.html>都道府県別</a>）

--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@ const init = function(data, data_bed, getBedCount) {
 	
 	let s = ''
 	//jpall.innerHTML = `${sum}人<div class=pcrsum>(検査数 ${addComma(data.ninspections)}, 陽性率 ${calcRatio(sum, data.ninspections)})</div>`
-	jpall.innerHTML = `<div class=jpalllabel>全国</div>${sum} / ${getBedCount(data_bed.total)}<div class=pcrsum>現在患者数 / 感染病床数<br>(累積${addComma(data.npatients)}, 退院${addComma(data.nexits)}, 死者${addComma(data.ndeaths)})</div>`
+	jpall.innerHTML = `<div class=jpalllabel>全国</div>${sum} / ${getBedCount(data_bed.total)}<div class=pcrsum>現在患者数 / 感染病床数*<br>(累積${addComma(data.npatients)}, 退院${addComma(data.nexits)}, 死者${addComma(data.ndeaths)})</div>`
 	//jpall.style.fontSize = "1.5vw"
 	jpall.style.background = 'var(--main-color)'
 	jpall.style.color = 'white'
@@ -505,7 +505,7 @@ const makeJapanHTML = function() {
 
 <div id=summary>
 	<table id=summarytable>
-		<tr><th>感染病床使用率（参考）</th><th>現在患者数</th></tr>
+		<tr><th>感染病床使用率（参考）*</th><th>現在患者数</th></tr>
 		<tr><td><span id=useratio></span></thd><td><span id=ncurrentpatients>-</span>人</td></tr>
 		<tr><th>累積退院者</th><th>死亡者</th></tr>
 		<tr><td><span id=nexits>-</span>人</td><td><span id=ndeaths>-</span>人</td></tr>
@@ -522,7 +522,9 @@ const makeJapanHTML = function() {
 			<label><input type=checkbox id='beds'>二種（一般・精神）</label>
 		</div>
 		<div id=beddescription>
-			※ 感染症使用率（参考） = 現在患者数 / 選択した感染症病床数の合計 (実情とは異なります)<br>
+			*感染症使用率（参考） = 現在患者数 / 選択した感染症病床数の合計<br>
+			*ここで示している感染症病床数は2019年4月1日時点のデータであるため、<br>
+			現在は増床されている可能性があります<br>
 			出典：<a href=https://www.mhlw.go.jp/bunya/kenkou/kekkaku-kansenshou15/02-02.html>感染症指定医療機関の指定状況｜厚生労働省</a>（<a href=bedforinfection.html>都道府県別</a>）
 		</div>
 	</div>


### PR DESCRIPTION
## 改善内容
- 感染病床使用率が極端に解釈されるのを防ぐために、以下の注釈を追加
```
*ここで示している感染症病床数は2019年4月1日時点のデータであるため、
現在は増床されている可能性があります
```
- 関連issue
#7 

## スクリーンショット
<img width="1440" alt="スクリーンショット 2020-03-25 19 21 22" src="https://user-images.githubusercontent.com/4206675/77529300-afcf3000-6ed2-11ea-827a-45938bda1a36.png">
